### PR TITLE
Removed default null from RequestException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 vendor/
+bin/
 .arcconfig

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.0.2
+
+### Changed
+- `ResponseInterface $response` argument in `\Paysera\Component\RestClientCommon\Exception\RequestException::__construct` and 
+`\Paysera\Component\RestClientCommon\Exception\RequestException::create` methods is now required.
+`\Paysera\Component\RestClientCommon\Exception\RequestException::getResponse` method does not return null.
+
 ## 2.0.0
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
   "minimum-stability": "stable",
   "require-dev": {
     "phpunit/phpunit": "^5.0"
+  },
+  "config": {
+    "bin-dir": "bin"
   }
 }

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -19,13 +19,13 @@ class RequestException extends \Exception
     /**
      * @param string $message
      * @param RequestInterface $request
-     * @param ResponseInterface|null $response
+     * @param ResponseInterface $response
      * @param \Exception|null $previous
      */
     public function __construct(
         $message,
         RequestInterface $request,
-        ResponseInterface $response = null,
+        ResponseInterface $response,
         \Exception $previous = null
     ) {
         parent::__construct($message, 0, $previous);
@@ -43,7 +43,7 @@ class RequestException extends \Exception
     }
 
     /**
-     * @return null|ResponseInterface
+     * @return ResponseInterface
      */
     public function getResponse()
     {
@@ -110,7 +110,7 @@ class RequestException extends \Exception
         return $this;
     }
 
-    public static function create(RequestInterface $request, ResponseInterface $response = null)
+    public static function create(RequestInterface $request, ResponseInterface $response)
     {
         $exception = new static(null, $request, $response);
 


### PR DESCRIPTION
Response exist in all RequestException instances.

Also, either response is not null, or `\Paysera\Component\RestClientCommon\Exception\RequestException::create` method could potentially trigger fatal errors due to `$response->getBody()` calls.