### PR TITLE
Fix throwing RuntimeException instead of RequestException

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ env:
   global:
     - COMPOSER_NO_INTERACTION="1"
 
+dist: trusty
+
 matrix:
   include:
     - php: 5.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.4.2
+### Fixed
+- Throws `RuntimeException` when trying to create `RequestException` and response body is not seekable
+
 ## 2.4.1
 ### Fixed
 - Basic authentication `Authorization` header must have prefix `Basic `

--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -2,6 +2,7 @@
 
 namespace Paysera\Component\RestClientCommon\Exception;
 
+use Exception;
 use RuntimeException;
 use InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;
@@ -10,7 +11,7 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * @api
  */
-class RequestException extends \Exception
+class RequestException extends Exception
 {
     private $request;
     private $response;
@@ -23,13 +24,13 @@ class RequestException extends \Exception
      * @param string $message
      * @param RequestInterface $request
      * @param ResponseInterface $response
-     * @param \Exception|null $previous
+     * @param Exception|null $previous
      */
     public function __construct(
         $message,
         RequestInterface $request,
         ResponseInterface $response,
-        \Exception $previous = null
+        Exception $previous = null
     ) {
         parent::__construct($message, 0, $previous);
 
@@ -128,7 +129,9 @@ class RequestException extends \Exception
         } catch (InvalidArgumentException $invalidArgumentException) {
             return $exception;
         } finally {
-            $response->getBody()->rewind();
+            if ($response->getBody()->isSeekable()) {
+                $response->getBody()->rewind();
+            }
         }
 
         if (isset($decodedResponse['error'])) {


### PR DESCRIPTION
When body is not seekable e.g. when using `$this->client->makeRawRequest($request, ['stream' => true])` a RuntimeException is thrown instead of RequestException from the library