### PR TITLE
Update RequestException.php

### DIFF
--- a/src/Exception/RequestException.php
+++ b/src/Exception/RequestException.php
@@ -117,7 +117,7 @@ class RequestException extends Exception
 
     public static function create(RequestInterface $request, ResponseInterface $response)
     {
-        $exception = new static(null, $request, $response);
+        $exception = new static('', $request, $response);
 
         if (!$response->getBody()->isReadable()) {
             return $exception;


### PR DESCRIPTION
Fix [info] Deprecated: Exception::__construct(): Passing null to parameter #1 ($message) of type string is deprecated (php 8.2)