### PR TITLE
Changed `\Paysera\Component\RestClientCommon\Entity\Result::getItems` to always return an array, empty one if the value is null.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.6.1
+### Fixed
+- Changed `\Paysera\Component\RestClientCommon\Entity\Result::getItems` to always return an array, empty one if the value is null.
+
 ## 2.7.0
 ### Changed
 - Minimal version of PHP is increased to `7.4`.

--- a/src/Entity/Result.php
+++ b/src/Entity/Result.php
@@ -62,7 +62,9 @@ abstract class Result extends Entity implements Iterator, Countable
 
     public function getItems()
     {
-        return $this->get($this->dataKey);
+        $items = $this->get($this->dataKey);
+
+        return is_array($items) ? $items : [];
     }
 
     public function getMetadata()


### PR DESCRIPTION
he Result class, which implements the Iterator interface, doesn't properly handle cases where the data for the specified key (default 'items') is not set or is not an array. This can lead to PHP errors when trying to iterate over a Result object using a foreach loop.