### PR TITLE
Suppress Symfony deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.7.2
+### Fixed
+- Suppress Symfony deprecations
+
 ## 2.7.1
 ### Changed
 - Bumped `psr/http-message` to `^2.0`

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
   "name": "paysera/lib-rest-client-common",
-  "version": "2.7.1",
   "description": "Base classes/helpers used in REST Clients",
   "autoload": {
     "psr-4": {

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -28,7 +28,7 @@ class Entity implements ArrayAccess
 
     /**
      * @param mixed $offset
-     * @return mixed|null
+     * @return mixed
      */
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)

--- a/src/Entity/Entity.php
+++ b/src/Entity/Entity.php
@@ -16,24 +16,41 @@ class Entity implements ArrayAccess
         $this->data = $data;
     }
 
+    /**
+     * @param mixed $offset
+     * @return bool
+     */
     #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->data);
     }
 
+    /**
+     * @param mixed $offset
+     * @return mixed|null
+     */
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->get($offset);
     }
 
+    /**
+     * @param mixed $offset
+     * @param mixed $value
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->set($offset, $value);
     }
 
+    /**
+     * @param mixed $offset
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {

--- a/src/Entity/Result.php
+++ b/src/Entity/Result.php
@@ -23,6 +23,9 @@ abstract class Result extends Entity implements Iterator, Countable
         $this->position = 0;
     }
 
+    /**
+     * @return Entity
+     */
     #[\ReturnTypeWillChange]
     public function current()
     {
@@ -30,30 +33,45 @@ abstract class Result extends Entity implements Iterator, Countable
         return $this->createItem($data);
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->position;
     }
 
+    /**
+     * @return int
+     */
     #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->position;
     }
 
+    /**
+     * @return bool
+     */
     #[\ReturnTypeWillChange]
     public function valid()
     {
        return isset($this->getItems()[$this->position]);
     }
 
+    /**
+     * @return void
+     */
     #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->position = 0;
     }
 
+    /**
+     * @return int
+     */
     #[\ReturnTypeWillChange]
     public function count()
     {


### PR DESCRIPTION
Suppress Symfony deprecations like the following:
```
User Deprecated: Method "ArrayAccess::offsetExists()" might add "bool" as a native return type declaration in the future. Do the same in implementation "Paysera\Component\RestClientCommon\Entity\Entity" now to avoid errors or add an explicit @return annotation to suppress this message.
User Deprecated: Method "ArrayAccess::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Paysera\Component\RestClientCommon\Entity\Entity" now to avoid errors or add an explicit @return annotation to suppress this message.
User Deprecated: Method "ArrayAccess::offsetSet()" might add "void" as a native return type declaration in the future. Do the same in implementation "Paysera\Component\RestClientCommon\Entity\Entity" now to avoid errors or add an explicit @return annotation to suppress this message.
User Deprecated: Method "ArrayAccess::offsetUnset()" might add "void" as a native return type declaration in the future. Do the same in implementation "Paysera\Component\RestClientCommon\Entity\Entity" now to avoid errors or add an explicit @return annotation to suppress this message.
```